### PR TITLE
Fixes 2 small bugs

### DIFF
--- a/src/main/java/watermelonmojito/elevatorsmod/server/ElevatorBlock.java
+++ b/src/main/java/watermelonmojito/elevatorsmod/server/ElevatorBlock.java
@@ -13,42 +13,46 @@ public class ElevatorBlock extends Block{
 		super(key, id, material);
 	}
 
-	public static void jump(World world, int x, int y, int z, EntityPlayer player){
+	// returns true if we teleported
+	public static boolean jump(World world, int x, int y, int z, EntityPlayer player){
 		int counter = 2;
 		for(int y2 = y+1; y2 < 255; y2++){
 			if(counter > 0){
 				counter--;
-				if (world.getBlockId(x, y2, z) == 437){
-					return;
+				if (world.getBlockId(x, y2, z) == Block.blockSteel.id){
+					break;
 				}
 			}
 			if(world.getBlock(x, y2, z) instanceof ElevatorBlock){
 				teleport(x+0.5, y2+1, z+0.5, player);
-
-				break;
+				return true;
 			}
 			else if (world.getBlockId(x, y2, z) != 0 && !ElevatorsMod.allowObstructions) {
 				break;
 			}
 		}
+		return false;
 	}
-	public static void sneak(World world, int x, int y, int z, EntityPlayer player){
+
+	// returns true if we teleported
+	public static boolean sneak(World world, int x, int y, int z, EntityPlayer player){
 		int counter = 2;
 		for(int y2 = y-1; y2 > 0; y2--){
 			if(counter > 0){
 				counter--;
-				if (world.getBlockId(x, y2, z) == 437){
-					return;
+				if (world.getBlockId(x, y2, z) == Block.blockSteel.id){
+					break;
 				}
 			}
 			if(world.getBlock(x, y2, z) instanceof ElevatorBlock){
 				teleport(x+0.5, y2+1, z+0.5, player);
-				break;
+				return true;
 			}
 			else if (world.getBlockId(x, y2, z) != 0 && !ElevatorsMod.allowObstructions) {
 				break;
 			}
 		}
+		return false;
 	}
 
 	public static void teleport(double x, double y, double z, EntityPlayer player){


### PR DESCRIPTION
Player continues their jump when going up an elevator

- Fixed with new mixin to the jump method, which prevents the player from jumping if they just used an elevator

You said in your thread this only happens in single player, but from what I tested it happens in both single player and multiplayer. This commit fixes it for players in single player or players in multiplayer who have the mod installed. Players in multiplayer without the mod are unaffected.

Randomly teleporting upwards after crouched on an elevator for a long enough period of time in SP

- Fixed just by increasing the velocity threshold before you are teleported